### PR TITLE
Testing precomp step in Pkg.test [Don't merge] 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,11 +9,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-url:
+          - 'https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.3-linux-x86_64.tar.gz' # 1.5.3
+          - 'https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.0-beta1-linux-x86_64.tar.gz' # 1.6.0-beta1
+          - 'https://s3.amazonaws.com/julialangnightlies/assert_pretesting/linux/x64/1.6/julia-d95cacb37b-linux64.tar.gz' # 1.6.0-beta1 + precomp
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - name: Install Julia from URL
+        uses: julia-actions/install-julia-from-url@main
         with:
-          version: 1
+          url: ${{ matrix.julia-url }}
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
+      #- uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
I hope you don't mind me doing some testing here. 
I've been using DifferentialEquations as a test for parallel precomp, and given that parallel precomp is about to be added to the internal install step within `Pkg.test`, I wanted to see how it goes as a test in the wild.

This obviously shouldn't be merged. The julia setup is specific to testing:
- 1.5.3
- 1.6.0-beta1 (no parallel precomp in Pkg.test)
- release-1.6 + parallel precomp in Pkg.test