### PR TITLE
A new round of ODE defaults

### DIFF
--- a/test/default_ode_alg_test.jl
+++ b/test/default_ode_alg_test.jl
@@ -20,16 +20,16 @@ sol = solve(prob_ode_2Dlinear; reltol = 1e-1)
 sol = solve(prob_ode_2Dlinear; reltol = 1e-7)
 
 @test typeof(sol.alg.algs[1]) <: Vern7
-@test typeof(sol.alg.algs[2]) <: Rodas4
+@test typeof(sol.alg.algs[2]) <: Rodas5P
 
 sol = solve(prob_ode_2Dlinear; reltol = 1e-10)
 
-@test typeof(sol.alg.algs[1]) <: Vern9
+@test typeof(sol.alg.algs[1]) <: Vern7
 @test typeof(sol.alg.algs[2]) <: Rodas5P
 
 sol = solve(prob_ode_2Dlinear; alg_hints = [:stiff])
 
-@test typeof(sol.alg) <: Rodas4
+@test typeof(sol.alg) <: Rodas5P
 
 sol = solve(prob_ode_2Dlinear; alg_hints = [:stiff], reltol = 1e-1)
 
@@ -46,18 +46,18 @@ prob_ode_bigfloat2Dlinear = ODEProblem(f, map(BigFloat, rand(4, 2)) .* ones(4, 2
     (0.0, 1.0))
 
 sol = solve(prob_ode_bigfloat2Dlinear; dt = 1 // 2^(4))
-@test typeof(sol.alg.algs[1]) <: Vern9
+@test typeof(sol.alg.algs[1]) <: Vern7
 @test typeof(sol.alg.algs[2]) <: Rodas5P
 
 default_algorithm(prob_ode_bigfloat2Dlinear; alg_hints = [:stiff])
 
 sol = solve(prob_ode_bigfloat2Dlinear; alg_hints = [:stiff])
 
-@test typeof(sol.alg) <: Rodas4
+@test typeof(sol.alg) <: Rodas5P
 
 sol = solve(prob_ode_bigfloat2Dlinear, nothing; alg_hints = [:stiff])
 
-@test typeof(sol.alg) <: Rodas4
+@test typeof(sol.alg) <: Rodas5P
 
 struct FooAlg end
 
@@ -73,7 +73,7 @@ prob = ODEProblem(f, rand(4, 2) .* ones(4, 2) / 2, (0.0, 1.0))
 
 sol = solve(prob; alg_hints = [:stiff])
 
-@test typeof(sol.alg) <: Rodas4
+@test typeof(sol.alg) <: Rodas5P
 
 sol = solve(prob; alg_hints = [:stiff], reltol = 1e-1)
 
@@ -81,13 +81,13 @@ sol = solve(prob; alg_hints = [:stiff], reltol = 1e-1)
 
 sol = solve(prob; alg_hints = [:stiff], callback = CallbackSet())
 
-@test typeof(sol.alg) <: Rodas4
+@test typeof(sol.alg) <: Rodas5P
 
 prob = ODEProblem(f, rand(4, 2) .* ones(4, 2) / 2, (0.0, 1.0))
 
 alg, kwargs = default_algorithm(prob; alg_hints = [:stiff])
 
-@test typeof(alg) <: Rodas4
+@test typeof(alg) <: Rodas5P
 
 m = 1.0
 ω = 1.0


### PR DESCRIPTION
Reasons:

1. Simplifies the number of potential solvers that can be used.
2. Changes CVODE out and uses a lot more FBDF as that solver is doing really well and FBDF supports mass matrices so that makes it easier.
3. All Vern9 -> Vern7 since when non-lazy Vern9 loses a lot of performance when it requires calculating all of the extra stages every time.
4. Rodas5P is just better so we can swap out the Rodas4 and such.

None of this should be breaking since the solvers are meant to be swappable, though performance on user codes will of course change.
