### PR TITLE
Fix steady state default algorithm test

### DIFF
--- a/test/default_steady_state_alg_test.jl
+++ b/test/default_steady_state_alg_test.jl
@@ -9,4 +9,4 @@ prob = SteadyStateProblem(f, u0)
 
 sol = solve(prob)
 
-@test sol.alg isa DifferentialEquations.NonlinearSolve.NewtonRaphson
+@test DifferentialEquations.NonlinearSolve.get_name(sol.alg) === :NewtonRaphson


### PR DESCRIPTION
Test was failing. This is probably a ripple effect of changes in NonlinearSolve.jl, DifferentialEquations.NonlinearSolve.NewtonRaphson now points to a function (not a type anymore). 

The change introduced compares the algorithm name instead of the type (using `NonlinearSolve.get_name`). The other way of fixing it would of course be to have the `NonlinearSolve.NewtonRaphson` also be a type instead of just a function (as it previously was).