### PR TITLE
Fix typo in ODE algorithms: Use FBDF for problems with > 50 states

### DIFF
--- a/src/ode_default_alg.jl
+++ b/src/ode_default_alg.jl
@@ -41,7 +41,7 @@ function default_algorithm(prob::DiffEqBase.AbstractODEProblem{uType, tType, inp
             if length(prob.u0) > 500
                 # Use Krylov method when huge!
                 alg = FBDF(autodiff = false, linsolve = LinearSolve.KrylovJL_GMRES())
-            elseif length(prob.u0) > 500
+            elseif length(prob.u0) > 50
                 alg = FBDF(autodiff = false)
             elseif tol_level == :high_tol
                 alg = Rosenbrock23(autodiff = false)


### PR DESCRIPTION
There are two identical conditions `length(prob.u0) > 500` in a single `if - elseif - ...` statement, so the second one is never hit. Based on the branches for problems with `:auto` hints below and the logic prior to https://github.com/SciML/DifferentialEquations.jl/pull/977, I assume that the second condition was introduced accidentally in https://github.com/SciML/DifferentialEquations.jl/pull/977 and was supposed to be `length(prob.u0) > 50`. 