### PR TITLE
fix: import precompile workload symbols explicitly

### DIFF
--- a/src/DifferentialEquations.jl
+++ b/src/DifferentialEquations.jl
@@ -2,14 +2,15 @@ module DifferentialEquations
 
 using Reexport: Reexport, @reexport
 using PrecompileTools: @compile_workload, @setup_workload
+import SciMLBase
+import SciMLBase: ODEProblem, solve
+import OrdinaryDiffEq
+import OrdinaryDiffEq: Rodas5P, Tsit5
 
 @reexport using SciMLBase
 @reexport using OrdinaryDiffEq
 
 @setup_workload begin
-    using SciMLBase: ODEProblem, solve
-    using OrdinaryDiffEq: Rodas5P, Tsit5
-
     scalar_problem = ODEProblem((u, p, t) -> p * u, 0.5, (0.0, 1.0), 1.01)
     stiff_problem = ODEProblem(
         (du, u, p, t) -> begin

--- a/src/DifferentialEquations.jl
+++ b/src/DifferentialEquations.jl
@@ -2,8 +2,8 @@ module DifferentialEquations
 
 using Reexport: Reexport, @reexport
 using PrecompileTools: @compile_workload, @setup_workload
-import SciMLBase
-import OrdinaryDiffEq
+import SciMLBase: ODEProblem, solve
+import OrdinaryDiffEq: Rodas5P, Tsit5
 
 @reexport using SciMLBase
 @reexport using OrdinaryDiffEq

--- a/src/DifferentialEquations.jl
+++ b/src/DifferentialEquations.jl
@@ -2,13 +2,14 @@ module DifferentialEquations
 
 using Reexport: Reexport, @reexport
 using PrecompileTools: @compile_workload, @setup_workload
-import SciMLBase: ODEProblem, solve
-import OrdinaryDiffEq: Rodas5P, Tsit5
 
 @reexport using SciMLBase
 @reexport using OrdinaryDiffEq
 
 @setup_workload begin
+    using SciMLBase: ODEProblem, solve
+    using OrdinaryDiffEq: Rodas5P, Tsit5
+
     scalar_problem = ODEProblem((u, p, t) -> p * u, 0.5, (0.0, 1.0), 1.01)
     stiff_problem = ODEProblem(
         (du, u, p, t) -> begin


### PR DESCRIPTION
Precompile workload failed because implicit imports from SciMLBase/OrdinaryDiffEq were not available during @compile_workload.

Import only the symbols used in the workload (ODEProblem, solve, Rodas5P, Tsit5).

Made with [Cursor](https://cursor.com)