### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,40 @@
+using DifferentialEquations, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# =============================================================================
+# ODE end-to-end solves
+# =============================================================================
+
+SUITE["ode"] = BenchmarkGroup()
+
+function lotka!(du, u, p, t)
+    du[1] = 1.5u[1] - u[1] * u[2]
+    du[2] = -3.0u[2] + u[1] * u[2]
+    return nothing
+end
+ode_prob = ODEProblem(lotka!, [1.0, 1.0], (0.0, 10.0))
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return nothing
+end
+lorenz_prob = ODEProblem(lorenz!, [1.0, 0.0, 0.0], (0.0, 50.0))
+
+SUITE["ode"]["tsit5"] = @benchmarkable solve($ode_prob, Tsit5())
+SUITE["ode"]["default_alg"] = @benchmarkable solve($ode_prob)
+SUITE["ode"]["vern7_lorenz"] = @benchmarkable solve($lorenz_prob, Vern7())
+
+# =============================================================================
+# Ensemble
+# =============================================================================
+
+SUITE["ensemble"] = BenchmarkGroup()
+
+prob_func(prob, ctx) = remake(prob; u0 = prob.u0 .* 1.01)
+eprob = EnsembleProblem(ode_prob; prob_func)
+SUITE["ensemble"]["serial_100"] = @benchmarkable solve(
+    $eprob, Tsit5(), EnsembleSerial(); trajectories = 100
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~24s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~24s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md